### PR TITLE
Wait for compute stats to finish before closing the cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ The available commands are:
 
     $ herringbone flatten -i /path/to/input/directory -o /path/to/output/directory
 
-`load`: load a directory of parquet files (which must have a flat schema) into impala or hive (defaulting to impala)
+`load`: load a directory of parquet files (which must have a flat schema) into impala or hive (defaulting to impala). Use the --nocompute-stats option for faster loading into impala (but probably slower querying later on!)
 
-    $ herringbone load [--hive] [-u] -d db_name -t table -p /path/to/parquet/directory
+    $ herringbone load [--hive] [-u] [--nocompute-stats] -d db_name -t table -p /path/to/parquet/directory
 
 `tsv`: transform a directory of parquet files into a directory of tsv files (which you can concat properly later with `hadoop fs -getmerge /path/to/tsvs`)
 

--- a/bin/herringbone
+++ b/bin/herringbone
@@ -7,7 +7,7 @@ The available commands are:
 
 flatten: Transform a directory of parquet files with a nested structure into a directory of parquet files with a flat schema that can be loaded into impala or hive
 
-load: Load a directory of parquet files (which must have a flat schema) into impala or hive (defaults to impala)
+load: Load a directory of parquet files (which must have a flat schema) into impala or hive (defaults to impala). Use the --nocompute-stats option for faster loading into impala (but probably slower querying later on!)
 
 tsv: Transform a directory of parquet files into a directory of tsv files (which you can concat properly later with `hadoop fs -getmerge /path/to/tsvs`)
 
@@ -18,7 +18,7 @@ Example usage:
 
 `herringbone flatten -i /path/to/input/directory -o /path/to/output/directory`
 
-`herringbone load [--hive] [-u] -d db_name -t table -p /path/to/parquet/directory`
+`herringbone load [--hive] [-u] [--nocompute-stats] -d db_name -t table -p /path/to/parquet/directory`
 
 `herringbone tsv -i /path/to/input/directory -o /path/to/output/directory`
 

--- a/herringbone-impala/src/main/scala/com/stripe/herringbone/impala/Connection.scala
+++ b/herringbone-impala/src/main/scala/com/stripe/herringbone/impala/Connection.scala
@@ -11,6 +11,7 @@ import scala.collection.JavaConversions._
 
 case class Connection(host: String, port: Int) {
   var isOpen = false
+  val logContext = "herringbone-impala"
   lazy val socket = new TSocket(host, port)
   lazy val client = new ClouderaImpalaClient(new TBinaryProtocol(socket))
 
@@ -54,7 +55,7 @@ case class Connection(host: String, port: Int) {
     val query = new Query
     query.query = raw
 
-    val handle = client.query(query)
+    val handle = client.executeAndWait(query, logContext)
     Cursor(handle, client)
   }
 

--- a/herringbone-main/src/main/scala/com/stripe/herringbone/load/ImpalaLoader.scala
+++ b/herringbone-main/src/main/scala/com/stripe/herringbone/load/ImpalaLoader.scala
@@ -46,7 +46,7 @@ case class ImpalaLoader(conf: ParquetLoadConf,
     execute("CREATE DATABASE IF NOT EXISTS %s".format(database))
     execute("DROP TABLE IF EXISTS %s.%s".format(database, table))
     execute("ALTER TABLE importing.%s RENAME TO %s.%s".format(table, database, table))
-    if (partitionFields.isEmpty) execute("COMPUTE STATS %s.%s".format(database, table))
+    if (partitionFields.isEmpty && conf.computeStats()) execute("COMPUTE STATS %s.%s".format(database, table))
   }
 
   def updateTable(table: String, database: String) {

--- a/herringbone-main/src/main/scala/com/stripe/herringbone/load/ParquetLoadConf.scala
+++ b/herringbone-main/src/main/scala/com/stripe/herringbone/load/ParquetLoadConf.scala
@@ -9,7 +9,7 @@ class ParquetLoadConf(arguments: Seq[String]) extends ScallopConf(arguments) {
   val hive = opt[Boolean]("hive")
   val connectionUrl = opt[String](required = true)
   val connectionPort = opt[String](required = true)
-
+  val computeStats = toggle(descrYes = "Compute table stats after loading files into impala. Turn this off for faster loading into impala (but probably slower querying later on!)", default = Some(true))
   val updatePartitions = toggle(descrYes = "Create table if not present, otherwise update with new partitions", default = Some(false))
   validateOpt (path, updatePartitions) {
     case (None, None) => Left("You must specify at least one of path or update-partitions")


### PR DESCRIPTION
We run `compute stats` after a `ParquetLoad` into Impala. `compute stats` is asynchronous, so we need to wait for it to finish before closing the connection
