### PR TITLE
Ensure we can write to the output directory

### DIFF
--- a/herringbone-main/src/main/scala/com/stripe/herringbone/CompactJob.scala
+++ b/herringbone-main/src/main/scala/com/stripe/herringbone/CompactJob.scala
@@ -70,6 +70,11 @@ class CompactJob extends Configured with Tool {
     val metadataJson = new ObjectMapper().writeValueAsString(metadata)
     getConf.set(ParquetCompactWriteSupport.ExtraMetadataKey, metadataJson)
 
+    if (fs.exists(outputPath)) {
+      println(s"Deleting existing $outputPath")
+      fs.delete(outputPath, true)
+    }
+
     val job = new Job(getConf)
 
     FileInputFormat.setInputPaths(job, inputPath)


### PR DESCRIPTION
Following the pattern in FlattenJob and TsvJob, where we delete the existing output path to ensure we can write to it when the job is done

r @DanielleSucher 
r @jbalogh 