### PR TITLE
Prevent OOM errors when compacting or flattening large files

### DIFF
--- a/herringbone-main/src/main/scala/com/stripe/herringbone/CompactJob.scala
+++ b/herringbone-main/src/main/scala/com/stripe/herringbone/CompactJob.scala
@@ -88,6 +88,7 @@ class CompactJob extends Configured with Tool {
     job.setMapperClass(classOf[Mapper[Void,Group,Void,Group]])
     job.setJarByClass(classOf[CompactJob])
     job.getConfiguration.set("mapreduce.job.user.classpath.first", "true")
+    job.getConfiguration.set(ParquetOutputFormat.ENABLE_JOB_SUMMARY, "false")
     job.setNumReduceTasks(0)
 
     if(job.waitForCompletion(true)) 0 else 1

--- a/herringbone-main/src/main/scala/com/stripe/herringbone/FlattenJob.scala
+++ b/herringbone-main/src/main/scala/com/stripe/herringbone/FlattenJob.scala
@@ -64,6 +64,7 @@ class FlattenJob extends Configured with Tool {
     job.setMapperClass(classOf[FlattenMapper])
     job.setJarByClass(classOf[FlattenJob])
     job.getConfiguration.set("mapreduce.job.user.classpath.first", "true")
+    job.getConfiguration.set(ParquetOutputFormat.ENABLE_JOB_SUMMARY, "false")
     job.setNumReduceTasks(0)
 
     if (job.waitForCompletion(true)) 0 else 1


### PR DESCRIPTION
From @jbalogh: "OOM happens because parquet writes a `_metadata` file that's representative of the schema of the individual `.parquet` files and when it's doing that it reads all(?) the parquet metadata from all the blocks and retains them in memory so that OOMs and crashes the process that's finishing up the mapreduce job"

r @jbalogh 
r @DanielleSucher 