### PR TITLE
Fix path handling

### DIFF
--- a/herringbone-main/src/main/scala/com/stripe/herringbone/FlattenJob.scala
+++ b/herringbone-main/src/main/scala/com/stripe/herringbone/FlattenJob.scala
@@ -47,8 +47,8 @@ class FlattenJob extends Configured with Tool {
     }
 
     val flattenedSchema = TypeFlattener.flatten(
-      ParquetUtils.readSchema(inputPath, fs),
-      previousPath.map { ParquetUtils.readSchema(_, fs) },
+      ParquetUtils.readSchema(inputPath),
+      previousPath.map { ParquetUtils.readSchema(_) },
       separator,
       renameId
     )

--- a/herringbone-main/src/main/scala/com/stripe/herringbone/TsvJob.scala
+++ b/herringbone-main/src/main/scala/com/stripe/herringbone/TsvJob.scala
@@ -53,8 +53,8 @@ class TsvJob extends Configured with Tool {
     }
 
     val flattenedSchema = TypeFlattener.flatten(
-      ParquetUtils.readSchema(inputPath, fs),
-      previousPath.map { ParquetUtils.readSchema(_, fs) },
+      ParquetUtils.readSchema(inputPath),
+      previousPath.map { ParquetUtils.readSchema(_) },
       separator,
       renameId
     )

--- a/herringbone-main/src/main/scala/com/stripe/herringbone/load/FieldUtils.scala
+++ b/herringbone-main/src/main/scala/com/stripe/herringbone/load/FieldUtils.scala
@@ -21,7 +21,7 @@ case class FieldUtils(hadoopFs: HadoopFs, schemaTypeMapper: SchemaTypeMapper) {
   }
 
   def findTableFields(path: Path) = {
-    val schema = ParquetUtils.readSchema(path, hadoopFs.fileSystem)
+    val schema = ParquetUtils.readSchema(path)
     tableFieldsFromSchemaFields(schema.getFields)
   }
 

--- a/herringbone-main/src/main/scala/com/stripe/herringbone/load/HadoopFs.scala
+++ b/herringbone-main/src/main/scala/com/stripe/herringbone/load/HadoopFs.scala
@@ -10,7 +10,7 @@ class HadoopFs {
   lazy val fileSystem = FileSystem.get(new Configuration)
 
   def findAbsolutePath(path: Path) = {
-    fileSystem.getFileStatus(path).getPath.toUri.getPath
+    fileSystem.getFileStatus(path).getPath.toUri.toString
   }
 
   def findSortedLeafPaths(path: Path): List[Path] =

--- a/herringbone-main/src/main/scala/com/stripe/herringbone/util/ParquetUtils.scala
+++ b/herringbone-main/src/main/scala/com/stripe/herringbone/util/ParquetUtils.scala
@@ -7,10 +7,11 @@ import org.apache.hadoop.fs._
 import parquet.hadoop.ParquetFileReader
 
 object ParquetUtils {
-  def getParquetMetadata(path: Path, fs: FileSystem) = {
+  def getParquetMetadata(path: Path) = {
     // Just use the first parquet file to figure out the impala fields
     // This also dodges the problem of any non-parquet files stashed
     // in the path.
+    val fs = path.getFileSystem(new Configuration)
     val parquetFileStatuses = fs.listStatus(path, parquetFilter)
     val representativeParquetPath = parquetFileStatuses.head.getPath
 
@@ -18,12 +19,12 @@ object ParquetUtils {
     footers.get(0).getParquetMetadata
   }
 
-  def readSchema(path: Path, fs: FileSystem) = {
-    getParquetMetadata(path, fs).getFileMetaData.getSchema
+  def readSchema(path: Path) = {
+    getParquetMetadata(path).getFileMetaData.getSchema
   }
 
-  def readKeyValueMetaData(path: Path, fs: FileSystem) = {
-    getParquetMetadata(path, fs).getFileMetaData.getKeyValueMetaData
+  def readKeyValueMetaData(path: Path) = {
+    getParquetMetadata(path).getFileMetaData.getKeyValueMetaData
   }
 
   val parquetFilter = new PathFilter {


### PR DESCRIPTION
Herringbone currently doesn't handle paths with schemes other than `fs.defaultFS` - in particular, s3 urls. This patch changes the code to use `Path.getFileSystem(conf)`, which is scheme-aware.

r? @DanielleSucher 