### PR TITLE
Upgrade Parquet to 1.6.0rc7

### DIFF
--- a/herringbone-main/pom.xml
+++ b/herringbone-main/pom.xml
@@ -97,7 +97,7 @@
   </build>
 
   <properties>
-    <parquet.version>1.6.0rc4</parquet.version>
+    <parquet.version>1.6.0rc7</parquet.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <scala.version>2.10.4</scala.version>
     <maven.compiler.source>1.7</maven.compiler.source>

--- a/herringbone-main/src/main/scala/com/stripe/herringbone/CompactInputFormat.scala
+++ b/herringbone-main/src/main/scala/com/stripe/herringbone/CompactInputFormat.scala
@@ -66,7 +66,7 @@ class CompactInputFormat[T](readSupportClass: Class[_ <: ReadSupport[T]]) extend
   }
 
   override def createRecordReader(split: InputSplit, context: TaskAttemptContext): MergedRecordReader[T] = {
-    val readSupport = getReadSupport(ContextUtil.getConfiguration(context))
+    val readSupport = ParquetInputFormat.getReadSupportInstance[T](ContextUtil.getConfiguration(context))
     split match {
       case s: MergedInputSplit => new MergedRecordReader[T](s, context, readSupport)
       case _ => throw new Exception(s"Expected a MergedInputSplit. Found a $split.")

--- a/herringbone-main/src/main/scala/com/stripe/herringbone/FlattenJob.scala
+++ b/herringbone-main/src/main/scala/com/stripe/herringbone/FlattenJob.scala
@@ -59,13 +59,15 @@ class FlattenJob extends Configured with Tool {
     FileInputFormat.setInputPaths(job, inputPath)
     FileOutputFormat.setOutputPath(job, outputPath)
     ExampleOutputFormat.setSchema(job, flattenedSchema)
+    ParquetInputFormat.setReadSupportClass(job, classOf[GroupReadSupport])
 
     job.setInputFormatClass(classOf[CompactGroupInputFormat]);
     job.setOutputFormatClass(classOf[ExampleOutputFormat])
     job.setMapperClass(classOf[FlattenMapper])
     job.setJarByClass(classOf[FlattenJob])
-    job.getConfiguration.set("mapreduce.job.user.classpath.first", "true")
-    job.getConfiguration.set(ParquetOutputFormat.ENABLE_JOB_SUMMARY, "false")
+    job.getConfiguration.setBoolean("mapreduce.job.user.classpath.first", true)
+    job.getConfiguration.setBoolean(ParquetOutputFormat.ENABLE_JOB_SUMMARY, false)
+    job.getConfiguration.setBoolean(ParquetInputFormat.TASK_SIDE_METADATA, false);
     job.setNumReduceTasks(0)
 
     if (job.waitForCompletion(true)) 0 else 1


### PR DESCRIPTION
We have to turn off task-side metadata reading so that CompactInputFormat has
the splits available to do math on.

r? @DanielleSucher 