### PR TITLE
Configure TsvJob to work with latest parquet version

### DIFF
--- a/herringbone-main/src/main/scala/com/stripe/herringbone/CompactInputFormat.scala
+++ b/herringbone-main/src/main/scala/com/stripe/herringbone/CompactInputFormat.scala
@@ -22,12 +22,11 @@ import parquet.example.data.simple.SimpleGroup
 
 class CompactInputFormat[T](readSupportClass: Class[_ <: ReadSupport[T]]) extends ParquetInputFormat[T](readSupportClass) {
 
-  // We can't accurately predict the size of the resulting merged file, so aim
-  // for 900MB. Our HDFS block size is 1024MB so we'll get pretty close.
-  val TARGET = 1024 * 1024 * 900 // 900MB.
+  // Our HDFS block size is 1024MB so we'll get pretty close.
+  val TARGET = 1024 * 1024 * 1024 // 1024MB.
 
   override def getSplits(context: JobContext): JavaList[InputSplit] = {
-    // Limit the splits to 100MB so it's easy to assemble them into 900MB
+    // Limit the splits to 100MB so it's easy to assemble them into 1024MB
     // chunks.  This is not actually reliable. Chunks can come back bigger than
     // 100MB, but it does limit the size of most chunks.
     val conf = ContextUtil.getConfiguration(context)

--- a/herringbone-main/src/main/scala/com/stripe/herringbone/TsvJob.scala
+++ b/herringbone-main/src/main/scala/com/stripe/herringbone/TsvJob.scala
@@ -64,6 +64,7 @@ class TsvJob extends Configured with Tool {
 
     FileInputFormat.setInputPaths(job, inputPath)
     FileOutputFormat.setOutputPath(job, outputPath)
+    ParquetInputFormat.setReadSupportClass(job, classOf[GroupReadSupport])
     ExampleOutputFormat.setSchema(job, flattenedSchema)
 
     job.setInputFormatClass(classOf[CompactGroupInputFormat])
@@ -71,6 +72,7 @@ class TsvJob extends Configured with Tool {
     job.setMapperClass(classOf[TsvMapper])
     job.setJarByClass(classOf[TsvJob])
     job.getConfiguration.set("mapreduce.job.user.classpath.first", "true")
+    job.getConfiguration.setBoolean(ParquetInputFormat.TASK_SIDE_METADATA, false)
     job.setNumReduceTasks(0)
 
     if (job.waitForCompletion(true)) {


### PR DESCRIPTION
r? @jvns or @colinmarc 

Looks like the last parquet version bump broke `herringbone tsv`. This should fix it. Manually tested it with @krivoire already, and it totally worked!