### PR TITLE
Update pom.xml to point to repos over TLS

### DIFF
--- a/herringbone-impala/pom.xml
+++ b/herringbone-impala/pom.xml
@@ -12,7 +12,7 @@
   <pluginRepositories>
     <pluginRepository>
       <id>dtrott</id>
-      <url>http://maven.davidtrott.com/repository</url>
+      <url>https://maven.davidtrott.com/repository</url>
     </pluginRepository>
   </pluginRepositories>
 

--- a/herringbone-main/pom.xml
+++ b/herringbone-main/pom.xml
@@ -12,7 +12,7 @@
   <pluginRepositories>
     <pluginRepository>
       <id>dtrott</id>
-      <url>http://maven.davidtrott.com/repository</url>
+      <url>https://maven.davidtrott.com/repository</url>
     </pluginRepository>
   </pluginRepositories>
 


### PR DESCRIPTION
Manually updating the pom.xml to ensure it reaches out to repositories over HTTPS. In this case both http://maven.davidtrott.com/repository and https://maven.davidtrott.com/repository don't resolve but just in case.